### PR TITLE
Fix account menu authentication actions

### DIFF
--- a/AnBiaoZhiJianTong/src/AnBiaoZhiJianTong.Shell/App.xaml.cs
+++ b/AnBiaoZhiJianTong/src/AnBiaoZhiJianTong.Shell/App.xaml.cs
@@ -74,6 +74,7 @@ namespace AnBiaoZhiJianTong.Shell
             containerRegistry.RegisterForNavigation<ImportFilePage>();
 
             containerRegistry.Register<LoginWindow>();
+            containerRegistry.Register<UserCenter>();
         }
 
 

--- a/AnBiaoZhiJianTong/src/AnBiaoZhiJianTong.Shell/ViewModels/MainWindowViewModel.cs
+++ b/AnBiaoZhiJianTong/src/AnBiaoZhiJianTong.Shell/ViewModels/MainWindowViewModel.cs
@@ -32,14 +32,16 @@ namespace AnBiaoZhiJianTong.Shell.ViewModels
         public bool IsUserAuthenticated
         {
             get => _isUserAuthenticated;
-            private set => SetProperty(ref _isUserAuthenticated, value);
+            private set
+            {
+                if (SetProperty(ref _isUserAuthenticated, value))
+                {
+                    RaisePropertyChanged(nameof(IsUserUnauthenticated));
+                }
+            }
         }
-        private string _accountActionText;
-        public string AccountActionText
-        {
-            get => _accountActionText;
-            private set => SetProperty(ref _accountActionText, value);
-        }
+
+        public bool IsUserUnauthenticated => !IsUserAuthenticated;
         public MainWindowViewModel(IAppConfiguration configuration, IAuthService authService, IEventAggregator eventAggregator)
         {
             _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
@@ -90,7 +92,6 @@ namespace AnBiaoZhiJianTong.Shell.ViewModels
         private void UpdateAuthenticationState(bool isAuthenticated)
         {
             IsUserAuthenticated = isAuthenticated;
-            AccountActionText = isAuthenticated ? "注销" : "登录";
         }
     }
 

--- a/AnBiaoZhiJianTong/src/AnBiaoZhiJianTong.Shell/Views/MainWindow.xaml
+++ b/AnBiaoZhiJianTong/src/AnBiaoZhiJianTong.Shell/Views/MainWindow.xaml
@@ -264,15 +264,26 @@
                                 </ContextMenu.DataContext>
                                 <MenuItem Header="用户中心"
                                           Style="{StaticResource MenuItemStyle}"
-                                          IsEnabled="{Binding IsUserAuthenticated}">
+                                          Visibility="{Binding IsUserAuthenticated, Converter={StaticResource BoolToVisibilityConverter}}"
+                                          Click="UserCenterMenuItem_Click">
                                     <MenuItem.Icon>
                                         <Image Source="{StaticResource SettingIcon}" Width="16" Height="16"/>
                                     </MenuItem.Icon>
                                 </MenuItem>
-                                <MenuItem x:Name="AccountMenuItem"
-                                          Header="{Binding AccountActionText}"
+                                <MenuItem x:Name="LoginMenuItem"
+                                          Header="登录"
                                           Style="{StaticResource MenuItemStyle}"
-                                          Click="AccountMenuItem_Click">
+                                          Visibility="{Binding IsUserUnauthenticated, Converter={StaticResource BoolToVisibilityConverter}}"
+                                          Click="LoginMenuItem_Click">
+                                    <MenuItem.Icon>
+                                        <Image Source="{StaticResource SettingIcon}" Width="16" Height="16"/>
+                                    </MenuItem.Icon>
+                                </MenuItem>
+                                <MenuItem x:Name="LogoutMenuItem"
+                                          Header="注销"
+                                          Style="{StaticResource MenuItemStyle}"
+                                          Visibility="{Binding IsUserAuthenticated, Converter={StaticResource BoolToVisibilityConverter}}"
+                                          Click="LogoutMenuItem_Click">
                                     <MenuItem.Icon>
                                         <Image Source="{StaticResource SettingIcon}" Width="16" Height="16"/>
                                     </MenuItem.Icon>

--- a/AnBiaoZhiJianTong/src/AnBiaoZhiJianTong.Shell/Views/MainWindow.xaml.cs
+++ b/AnBiaoZhiJianTong/src/AnBiaoZhiJianTong.Shell/Views/MainWindow.xaml.cs
@@ -60,7 +60,17 @@ namespace AnBiaoZhiJianTong.Shell.Views
             Close();
         }
 
-        private void AccountMenuItem_Click(object sender, RoutedEventArgs e)
+        private void LoginMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            if (_authService != null && _authService.IsAuthenticated)
+            {
+                return;
+            }
+
+            ShowLoginDialog();
+        }
+
+        private void LogoutMenuItem_Click(object sender, RoutedEventArgs e)
         {
             if (_authService == null || _eventAggregator == null)
             {
@@ -69,13 +79,24 @@ namespace AnBiaoZhiJianTong.Shell.Views
 
             if (!_authService.IsAuthenticated)
             {
-                ShowLoginDialog();
+                return;
             }
-            else
+
+            _authService.Logout();
+            _eventAggregator.GetEvent<LoginInfoEvent>().Publish(null);
+        }
+
+        private void UserCenterMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            if (_container == null)
             {
-                _authService.Logout();
-                _eventAggregator.GetEvent<LoginInfoEvent>().Publish(null);
+                return;
             }
+
+            var userCenterWindow = _container.Resolve<Views.Windows.UserCenter>();
+            userCenterWindow.Owner = this;
+            userCenterWindow.WindowStartupLocation = WindowStartupLocation.CenterOwner;
+            userCenterWindow.ShowDialog();
         }
 
         private void ShowLoginDialog()

--- a/AnBiaoZhiJianTong/src/AnBiaoZhiJianTong.Shell/Views/Windows/UserCenter.xaml
+++ b/AnBiaoZhiJianTong/src/AnBiaoZhiJianTong.Shell/Views/Windows/UserCenter.xaml
@@ -10,7 +10,8 @@
         WindowStyle="None"
         ResizeMode="NoResize"
         Title="UserCenter" Height="700" Width="1000"
-        SizeToContent="Manual">
+        SizeToContent="Manual"
+        WindowStartupLocation="CenterOwner">
     <Border CornerRadius="6" BorderBrush="#DDDDDD" BorderThickness="1" Background="White" SnapsToDevicePixels="True">
         <Grid>
             <Grid.RowDefinitions>

--- a/AnBiaoZhiJianTong/src/AnBiaoZhiJianTong.Shell/Views/Windows/UserCenter.xaml.cs
+++ b/AnBiaoZhiJianTong/src/AnBiaoZhiJianTong.Shell/Views/Windows/UserCenter.xaml.cs
@@ -1,11 +1,5 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
-using AnBiaoZhiJianTong.Shell.ViewModels;
-using Prism.Events;
-using Prism.Ioc;
 
 namespace AnBiaoZhiJianTong.Shell.Views.Windows
 {
@@ -17,25 +11,8 @@ namespace AnBiaoZhiJianTong.Shell.Views.Windows
         public UserCenter()
         {
             InitializeComponent();
-            CenterWindow();
         }
-        private void CenterWindow()
-        {
-            // 获取屏幕的工作区域
-            foreach (Window parentWindow in Application.Current.Windows)
-            {
-                if (parentWindow.Name == "TheMainWindow") // 根据窗体名称来判断
-                {
-                    double parentX = parentWindow.Left;
-                    double parentY = parentWindow.Top;
-                    double x = (parentWindow.Width - this.Width) / 2;
-                    double y = (parentWindow.Height - this.Height) / 2;
-                    this.Left = (int)(parentX + x);
-                    this.Top = (int)(parentY + y);
-                    break;
-                }
-            }
-        }
+
         /// <summary>
         /// 标题栏鼠标左键按下 - 用于拖拽窗口
         /// </summary>
@@ -43,15 +20,16 @@ namespace AnBiaoZhiJianTong.Shell.Views.Windows
         {
             if (e.LeftButton == MouseButtonState.Pressed)
             {
-                this.DragMove();
+                DragMove();
             }
         }
+
         /// <summary>
         /// 关闭按钮点击
         /// </summary>
         private void CloseButton_Click(object sender, RoutedEventArgs e)
         {
-            this.Close();
+            Close();
         }
     }
-    }
+}


### PR DESCRIPTION
## Summary
- adjust the avatar context menu so it only shows login when unauthenticated and reveals user center and logout after login
- update the main window view model to expose authentication state helpers for the menu bindings
- register and center the user center dialog while cleaning up its code-behind

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d12afebb648332af5cf00ed42d8896